### PR TITLE
Fix NaN% in perf results

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -316,10 +316,7 @@ fn fill_perf(log: &slog::Logger, perf: &std::path::Path, new: &mut Nightly, old:
                         None => continue,
                         Some(v) => v,
                     };
-                    let v = match v.get(0) {
-                        None => continue,
-                        Some(v) => v,
-                    };
+                    let v = v.get(0).unwrap_or(v);
                     let v = match v.get("runs") {
                         None => continue,
                         Some(v) => v,


### PR DESCRIPTION
I noticed something wrong in the [latest tweets](https://twitter.com/rust_at_sunrise/status/935668810463531008), and checked whether I could fix it.

Although I'm not used to observing Rust performance benchmark results, it seems that the format has been simplified as of recently. The value at the "Ok" key is not wrapped by an array, which means that one of the `v.get(0)` statements was extraneous. I adjusted the code so as to be compatible with both forms.